### PR TITLE
[iOS] Fix for memory leak when check if WiFi is enabled

### DIFF
--- a/src/ios/WifiWizard2.m
+++ b/src/ios/WifiWizard2.m
@@ -36,6 +36,8 @@
         }
     }
 
+    freeifaddrs(interfaces);
+
     return [cset countForObject:@"awdl0"] > 1 ? YES : NO;
 }
 


### PR DESCRIPTION
[VAVESW-2546](https://vavehealth.atlassian.net/browse/VAVESW-2546)